### PR TITLE
Dashes in module names lead to errors

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "package_name": "packagename",
-    "module_name": "{{ cookiecutter.package_name|lower()|replace(' ', '-') }}",
+    "module_name": "{{ cookiecutter.package_name|lower()|replace(' ', '_')|replace('-', '_') }}",
     "short_description": "Does useful things.",
     "author_name": "Jane Doe",
     "author_email": "a@b",


### PR DESCRIPTION
Force removes "-" in module name because this will lead to errors later on.